### PR TITLE
Use HTTPS to reference external resources

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -20,7 +20,7 @@
 @font-subsets: "latin,cyrillic-ext,cyrillic,latin-ext";
 // @import url(http://fonts.googleapis.com/css?family=Dosis:200,300,400,600|Signika+Negative:300,400,600|Exo:300,400,600|Roboto:100,400,300,700|Sintony:400,700);
 // @import ~"url(http://fonts.googleapis.com/css?family=Roboto:100,400,300,700|Sintony:400,700&subset=@{font-subsets})"; // For some reason, this is failing in lessc 2.4.0
-@import url(http://fonts.googleapis.com/css?family=Roboto:100,400,300,700|Sintony:200,400,700&subset=latin,latin-ext,cyrillic,cyrillic-ext);
+@import url(https://fonts.googleapis.com/css?family=Roboto:100,400,300,700|Sintony:200,400,700&subset=latin,latin-ext,cyrillic,cyrillic-ext);
 
 // @font-family-sans-serif: 'Dosis', sans-serif;
 // @font-family-sans-serif: 'Signika Negative', sans-serif;


### PR DESCRIPTION
*Otherwise there will be warnings or browser won't load that resource at all on secure pages.*